### PR TITLE
Fix the logic for filtering our false-y jobs

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -787,7 +787,7 @@ Queue.prototype.clean = function (grace, type) {
     _this[getter]().then(function (jobs) {
       //take all jobs outside of the grace period
       return Promise.filter(jobs, function (job) {
-        return (!job || !job.timestamp) || (job.timestamp < Date.now() - grace);
+        return job && ((!job.timestamp) || (job.timestamp < Date.now() - grace));
       });
     }).then(function (jobs) {
       //remove those old jobs


### PR DESCRIPTION
I miss read the Promise chain. `Promise.filter()` needs to return false if `job` is a falsey value. If `job` is true, then it is safe to access the `timestampt` property.
