### PR TITLE
Releasing lock from processStalledJobs

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -550,7 +550,14 @@ Queue.prototype.processStalledJob = function(job){
         return _this.client.sismemberAsync(key, job.jobId).then(function(isMember){
           if(!isMember){
             return _this.processJob(job);
+          } else {
+            return job.releaseLock(_this.token);
           }
+        }).catch(function(err) {
+          // Any uncaught error will come here. We'll ensure that the job lock is released and rethrow
+          // the error so it bubbles normally
+          job.releaseLock(_this.token);
+          throw err;
         });
       }
     });


### PR DESCRIPTION
Queue#processStalledJobs takes the lock when attempting to process a job, but the lock is not released unless the job is not in `completed`. This means that jobs will remain locked if not processed until expired by the ttl set with `LOCK_RENEW_TIME`
