### PR TITLE
Adding dontProcessStalledJobs property

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -178,6 +178,9 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
   this.processJobs = this.processJobs.bind(this);
   this.takeLockAndProcessJob = this.takeLockAndProcessJob.bind(this);
   this.getJobFromId = Job.fromId.bind(null, this);
+
+  // If true, `processStalledJobs` will stop looking for stalled jobs to reprocess
+  this.dontProcessStalledJobs = false;
 };
 
 util.inherits(Queue, events.EventEmitter);
@@ -559,7 +562,7 @@ Queue.prototype.processStalledJob = function(job){
 
 Queue.prototype.processJobs = function(){
   return (this.paused || Promise.resolve())
-    .then(this.processStalledJobs)
+    .then(this.dontProcessStalledJobs ? Promise.resolve() : this.processStalledJobs)
     .then(this.getNextJob)
     .then(this.takeLockAndProcessJob)
     // Avoid https://github.com/OptimalBits/bull/issues/243


### PR DESCRIPTION
To optionally avoid processing stalled jobs
