### PR TITLE
Change name to bull-experimental in develop branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "bull",
+  "name": "bull-experimental",
   "version": "0.7.2",
   "description": "Job manager",
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git://github.com/OptimalBits/bull.git"
+    "url": "git://github.com/mixmaxhq/bull.git"
   },
   "keywords": [
     "job",


### PR DESCRIPTION
The develop branch will have the bull-experimental name in order to allow for two parallel versions of bull in our applications.

Once we tag a version for a release, we must change the name to `bull`
