### PR TITLE
Fix Bluebird warning

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -569,7 +569,7 @@ Queue.prototype.processStalledJob = function(job){
 
 Queue.prototype.processJobs = function(){
   return (this.paused || Promise.resolve())
-    .then(this.dontProcessStalledJobs ? Promise.resolve() : this.processStalledJobs)
+    .then(this.dontProcessStalledJobs ? Promise.resolve : this.processStalledJobs)
     .then(this.getNextJob)
     .then(this.takeLockAndProcessJob)
     // Avoid https://github.com/OptimalBits/bull/issues/243


### PR DESCRIPTION
The problem here is that the `thenable` passed when
`this.dontProcessStalledJobs` is a resolved Promise. However, by the
specification of Promises, the `thenable` must be a _function_ that
_resolves to_ a Promise.

The fix is to pass `Promise.resolve` instead, without
invoking. `Promise.resolve` is an utility function that returns a resolved
Promise.

No state is leaked to subsequent thenable functions (this is by design
of Promises) so doing this is safe.

This patch is to be reverted once we migrate to 1.0rc and implement a
proper opt-in/opt-out for processStalledJobs feature.

We discussed an alternate implementation on #eng, but some details
have been lost in slack, we discussed moving this check to some other
but I think it's not worth it given that:
- The current implementation doesn't work because we are passing a 
  resolved promise rather than a function that returns a resolved promise
- Making changes in other places just makes the change more risky than
  it should be - this patch is to be reverted once we upgrade to 1.0rc
