### PR TITLE
Dont wait for stalled jobs

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -430,17 +430,16 @@ Queue.prototype.run = function(concurrency){
   var promises = [];
   var _this = this;
 
+  while(concurrency--){
+    promises.push(new Promise(_this.processJobs));
+  }
+
   // In case of connection loss, running `processStalledJobs` will repick jobs here.
   var start = this.opts.processStalledJobs ? this.processStalledJobs() : Promise.resolve();
 
-  return start.then(function(){
-
-    while(concurrency--){
-      promises.push(new Promise(_this.processJobs));
-    }
-
+  promises.push(start.then(function(){
     //
-    // Set process Stalled jobs intervall
+    // Set process Stalled jobs interval
     //
     clearInterval(_this.stalledJobsInterval);
     if(_this.opts.processStalledJobs) {
@@ -448,9 +447,9 @@ Queue.prototype.run = function(concurrency){
         setInterval(_this.processStalledJobs, _this.LOCK_RENEW_TIME);
 
     }
+  }));
 
-    return Promise.all(promises);
-  });
+  return Promise.all(promises);
 };
 
 // ---------------------------------------------------------------------


### PR DESCRIPTION
This PR addresses upstream issue reported here: https://github.com/OptimalBits/bull/issues/313

`Queue#run` awaits until all stalled jobs are processed before kicking the main job process loop, this is problematic because processing stalled jobs is a slow operation (it is done in serial) and it can take a long time (my stress tests suggested upwards of 7 minutes) until new jobs are processed.

The fix consist in running the initial stalled job processing fired by `Queue#run` in parallel, so that the process job loop kicks right away, so that new jobs start processing just fine.

This approach is not completely accepted by Bull's author, however this is a real issue that needs addressing, particularly with our expected job volume, we can't be blocked for minutes and not process any jobs.
